### PR TITLE
pygments 2.11.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "pygments" %}
 {% set version = "2.11.2" %}
 
 package:
-  name: pygments
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/P/Pygments/Pygments-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Pygments-{{ version }}.tar.gz
   sha256: 4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a
 
 build:
@@ -17,31 +18,30 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
+    - setuptools
     - wheel
   run:
     - python >=3.5
-    - setuptools
 
 test:
   imports:
-    - pygments.styles
     - pygments
-    - pygments.lexers
     - pygments.filters
     - pygments.formatters
-    - pygments.plugin
+    - pygments.lexers
+    - pygments.styles
+  requires:
+    - pip
   commands:
     - pip check
     - pygmentize -h
-  requires:
-    - pip
 
 
 about:
-  home: http://pygments.org/
-  license: BSD-2-clause
+  home: https://pygments.org/
+  license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Pygments is a generic syntax highlighter suitable for use in code hosting, forums, wikis or other applications that need to prettify source code.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.10.0" %}
+{% set version = "2.11.2" %}
 
 package:
   name: pygments
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/P/Pygments/Pygments-{{ version }}.tar.gz
-  sha256: f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6
+  sha256: 4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a
 
 build:
   number: 0


### PR DESCRIPTION
Update pygments to 2.11.2

Version change: bump version number from 2.10.0 to 2.11.2
Bug Tracker: new open issues https://github.com/pygments/pygments/issues
Github releases:  https://github.com/pygments/pygments/releases
Upstream license:  License file:  https://github.com/pygments/pygments/blob/master/LICENSE
Upstream setup.cfg:  https://github.com/pygments/pygments/blob/2.11.2/setup.cfg

The package pygments is mentioned inside the packages:
airflow | bpython | ipython | ipython-5.x | jupyter_console | jupyterlab_pygments | mayavi | mercurial | nbconvert | prompt_toolkit-1.0.15 | pydruid | pyface | pyramid_debugtoolbar | qtconsole | readme_renderer | rich | runipy | sphinx | spyder |

Actions:
1. Use jinja2 templates in urls
2. Fix python in `host`
3. Add `setuptools` in `host`
4. Update test/imports
5. Fix license name
6. Fix `home_url` with https

Result:
- all-succeeded
