### PR TITLE
update 2.15.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Pygments is a generic syntax highlighter suitable for use in code hosting, forums, wikis or other applications that need to prettify source code.
-  Description: |
+  description: |
     This is the source of Pygments. It is
     a generic syntax highlighter written in Python
     that supports over 500 languages and text formats,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   entry_points:
     - pygmentize = pygments.cmdline:main
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
   skip: True  # [py<37]
 requirements:
   host:
@@ -45,6 +45,12 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Pygments is a generic syntax highlighter suitable for use in code hosting, forums, wikis or other applications that need to prettify source code.
+  Description: |
+    This is the source of Pygments. It is
+    a generic syntax highlighter written in Python
+    that supports over 500 languages and text formats,
+    for use in code hosting, forums, wikis or other applications
+    that need to prettify source code.
   dev_url: https://github.com/pygments/pygments
   doc_url: https://pygments.org/docs/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pygments" %}
-{% set version = "2.11.2" %}
+{% set version = "2.15.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,15 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Pygments-{{ version }}.tar.gz
-  sha256: 4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a
+  sha256: 8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c
 
 build:
   number: 0
-  noarch: python
   entry_points:
     - pygmentize = pygments.cmdline:main
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
-
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<37]
 requirements:
   host:
     - python
@@ -23,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.5
+    - python
 
 test:
   imports:
@@ -32,6 +31,7 @@ test:
     - pygments.formatters
     - pygments.lexers
     - pygments.styles
+    - pygments.plugin
   requires:
     - pip
   commands:


### PR DESCRIPTION
## `Pygments 2.15.1` Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1837)
[Upstream](https://github.com/pygments/pygments/tree/2.15.1)
[Dependencies ](https://github.com/pygments/pygments/blob/2.15.1/pyproject.toml)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added skip for versions less than 3.7 as support has dropped upstream